### PR TITLE
feat: check if the value already has units before adding 'rem'

### DIFF
--- a/src/auro-tokenlist.js
+++ b/src/auro-tokenlist.js
@@ -60,10 +60,22 @@ class AuroTokenList extends LitElement {
   /**
    * @private
    * @param {string} arg Token.
+   * @param {string} value Token value.
    * @returns {string} Token size.
    */
-  size(arg) {
-    return arg.includes("size") ? 'rem' : '';
+  size(arg, value) {
+    // Only add 'rem' if it's a size token AND doesn't already have units
+    if (arg.includes("size")) {
+      const valueStr = String(value);
+      if (valueStr.includes('px') || valueStr.includes('rem') || valueStr.includes('em') || valueStr.includes('%')) {
+        // Already has units, don't add more
+        return '';
+      }
+      // Add rem unit
+      return 'rem';
+    }
+    // Not a size token
+    return '';
   }
 
   /**
@@ -131,7 +143,7 @@ class AuroTokenList extends LitElement {
             ${varName(index.token, 'css')}
           </td>
           <td>
-            ${index.tokenvalue}${this.size(index.token)}${this.unit}
+            ${index.tokenvalue}${this.size(index.token, index.tokenvalue)}${this.unit}
           </td>
           <td>
     ${this.swatchType === "circle" || this.swatchType === "rectangle"


### PR DESCRIPTION
# Alaska Airlines Pull Request

`auro-tokenlist` is adding `rem` to the ends of values before confirming if a value such as `px`, etc already exists. This in turn creates compounded values such as `pxrem`.

### Testing

Tested locally in `node_modules`.

### Additional context

Blocking: https://github.com/AlaskaAirlines/AuroDesignTokens/issues/254

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Prevent adding redundant units to size tokens by checking if units already exist

Bug Fixes:
- Fix issue of compounding units (e.g., 'pxrem') when adding 'rem' to tokens that already have units

Enhancements:
- Improve unit handling logic to check for existing units before adding 'rem'