### PR TITLE
fix: only add 'rem' to ds-size tokens (auro classic)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-tokenlist",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-tokenlist",
-      "version": "1.2.1",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/auro-tokenlist.js
+++ b/src/auro-tokenlist.js
@@ -64,8 +64,10 @@ class AuroTokenList extends LitElement {
    * @returns {string} Token size.
    */
   size(arg, value) {
+    // Supports Auro Classic tokens only & provided for backwards compatibility
     // Only add 'rem' if it's a size token AND doesn't already have units
-    if (arg.includes("size")) {
+    // Check for "ds-size" or "-size-" patterns in ds tokens
+    if (arg.match(/ds-size|ds-.*-size-/iu)) {
       const valueStr = String(value);
       if (valueStr.includes('px') || valueStr.includes('rem') || valueStr.includes('em') || valueStr.includes('%')) {
         // Already has units, don't add more


### PR DESCRIPTION
# Alaska Airlines Pull Request

The regex for adding `rem` to Auro Classic `ds-size` token values is incorrectly adding the suffix to new themeable tokens (non-Auro Classic) that contain the word `emphasized`.

Spotted on [DocSite](https://auro.alaskaair.com/getting-started/developers/design-tokens/alaska):

Before:
```
var(--ds-advanced-color-shared-emphasized-background) -  rgba(1, 66, 106, 0.1)rem	
var(--ds-advanced-color-shared-emphasized-background-hover) - rgba(1, 66, 106, 0.2)rem
```

After:
```
var(--ds-advanced-color-shared-emphasized-background) -  rgba(1, 66, 106, 0.1)	
var(--ds-advanced-color-shared-emphasized-background-hover) - rgba(1, 66, 106, 0.2)
```

## Testing

Created a visual diff of local changes against the DocSite.

Noted that Auro Classic values did not change (expected):

<img width="1694" height="45482" alt="UntitledDiff (1)" src="https://github.com/user-attachments/assets/bd65c652-7fbf-422b-85f8-93af831304ca" />

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Restrict unit addition in AuroTokenList.size() to Auro Classic ds-size tokens by matching "ds-size" patterns, preventing incorrect unit duplication and preserving backwards compatibility.

Bug Fixes:
- Ensure 'rem' is only appended to ds-size design tokens and not to tokens that already include units or to non-size tokens

Enhancements:
- Refine size() method to accurately match Auro Classic ds-size token patterns using updated regex for backwards compatibility

## Summary by Sourcery

Restrict rem unit suffix addition to Auro Classic ds-size tokens by refining the size() method’s regex match to prevent incorrect unit duplication on non-size or themeable tokens.

Bug Fixes:
- Prevent 'rem' suffix from being appended to non-ds-size or already-unit-suffixed tokens.

Enhancements:
- Update size() method to use a precise regex for Auro Classic ds-size token patterns, preserving backwards compatibility.