### PR TITLE
feat: add support for gradient tokens

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-./node_modules/.bin/npm-run-all preCommit test linters postinstall
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "sinon": "^21.0.0"
       },
       "devDependencies": {
-        "@aurodesignsystem/design-tokens": "^8.4.2",
+        "@aurodesignsystem/design-tokens": "^8.5.0",
         "@aurodesignsystem/eslint-config": "^1.3.5",
-        "@aurodesignsystem/webcorestylesheets": "^10.0.4",
+        "@aurodesignsystem/webcorestylesheets": "^10.1.1",
         "@babel/eslint-parser": "^7.28.4",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.2.tgz",
-      "integrity": "sha512-sbFI6sRfV4z81cTp0GGCfgMWLpZX/mQ0P/4MAIyzxGgJ+x5yDGlfBW80Vr8no3bsAWPgMCINwrN498JM/9loxw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.5.0.tgz",
+      "integrity": "sha512-RygKVYYU5c9d78MXRxXSO+VQTmpqzvyxk+MgsmtPex6eG5R++PuJbCTK8UYOSG9pUdPV11cX2/avtgJIrJPPJw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -495,13 +495,13 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.0.4.tgz",
-      "integrity": "sha512-hUAsrXCiUpOfwkMZ2gI+oKY9oQRNQfeC1Edbf7OBqfhAPaXLbZ3kEivoEYqyI9XOC7Bf0dOdObHXIXAdrOynXQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.1.1.tgz",
+      "integrity": "sha512-aD0NKjmDgavZBSaFkfKNYLZwIoKH2iOf/m19kCnQklNqae4jceGV5vVi8Qyx6MH2/02rn4SuiaDXjCdA6tMX2g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.4.1",
+        "@aurodesignsystem/design-tokens": "8.5.0",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -509,20 +509,6 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
-      }
-    },
-    "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.1.tgz",
-      "integrity": "sha512-eL3WJAroHWrkoRi/5h53auyFzNiS57mxfdjML8C6nf8wV+KtJvwiNU0oaGsLHPAzicLPxuptkEM04oTo+V8LQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.6"
-      },
-      "engines": {
-        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-tokenlist",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-tokenlist",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "focus-visible": "^5.2.0"
   },
   "devDependencies": {
-    "@aurodesignsystem/design-tokens": "^8.4.2",
+    "@aurodesignsystem/design-tokens": "^8.5.0",
     "@aurodesignsystem/eslint-config": "^1.3.5",
-    "@aurodesignsystem/webcorestylesheets": "^10.0.4",
+    "@aurodesignsystem/webcorestylesheets": "^10.1.1",
     "@babel/eslint-parser": "^7.28.4",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",

--- a/src/styles/style-tokenlist.scss
+++ b/src/styles/style-tokenlist.scss
@@ -10,6 +10,12 @@
 @use "@aurodesignsystem/webcorestylesheets/src/breakpoints";
 @use "@aurodesignsystem/webcorestylesheets/src/core";
 
+$rectangle-swatch-width: 8rem !default;
+$rectangle-swatch-height: 1rem !default;
+
+$circle-swatch-width: 40px !default;
+$circle-swatch-height: 40px !default;
+
 /* stylelint-disable font-weight-notation */
 table {
   width: 100%;
@@ -60,6 +66,13 @@ td {
   }
 }
 
+// Gradient strings are long, so allow them to wrap
+.value {
+  &.is-gradient {
+    white-space: pre-wrap;
+  }
+}
+
 tr {
   &:nth-child(even) {
     background-color: var(--ds-color-brand-gray-100, vac.$ds-color-brand-gray-100);
@@ -77,18 +90,28 @@ tr {
 
 .swatch {
   &--rectangle {
-    width: 8rem;
-    height: 1rem;
+    width: $rectangle-swatch-width;
+    height: $rectangle-swatch-height;
     margin: 0 auto;
     outline: 1px solid var(--ds-color-brand-neutral-400, vac.$ds-color-brand-neutral-400);
     outline-offset: var(--ds-size-50, vac.$ds-size-50);
+    
+    // If the swatch is a gradient, give it height
+    &.is-gradient {
+      height: $rectangle-swatch-width;
+    }
   }
 
   &--circle {
-    width: 40px;
-    height: 40px;
+    width: $circle-swatch-width;
+    height: $circle-swatch-height;
     border-radius: 50%;
     margin: 0 auto;
     outline: none;
+
+    // If the swatch is a gradient, give it height
+    &.is-gradient {
+      height: $circle-swatch-width;
+    }
   }
 }

--- a/test/auro-tokenlist.test.js
+++ b/test/auro-tokenlist.test.js
@@ -57,11 +57,15 @@ describe('auro-tokenlist', () => {
 
     await expect(tableBodyRow1.querySelector("td:nth-of-type(1)")).to.contain.text("var(--ds-color-brand-atlas-100)");
     await expect(tableBodyRow1.querySelector("td:nth-of-type(2)")).to.contain.text("#cde6ff");
-    await expect(tableBodyRow1.querySelector("td:nth-of-type(3)")).to.contain.html(`<div class="swatch--rectangle" style="background-color: var(--ds-color-brand-atlas-100)">`);
+    const swatch1 = tableBodyRow1.querySelector("td:nth-of-type(3) div.swatch--rectangle");
+    await expect(swatch1).to.exist;
+    await expect(swatch1.style.background).to.equal("var(--ds-color-brand-atlas-100)");
 
     await expect(tableBodyRow2.querySelector("td:nth-of-type(1)")).to.contain.text("var(--ds-color-brand-atlas-200)");
     await expect(tableBodyRow2.querySelector("td:nth-of-type(2)")).to.contain.text("#6bb7fb");
-    await expect(tableBodyRow2.querySelector("td:nth-of-type(3)")).to.contain.html(`<div class="swatch--rectangle" style="background-color: var(--ds-color-brand-atlas-200)">`);
+    const swatch2 = tableBodyRow2.querySelector("td:nth-of-type(3) div.swatch--rectangle");
+    await expect(swatch2).to.exist;
+    await expect(swatch2.style.background).to.equal("var(--ds-color-brand-atlas-200)");
 
   });
 
@@ -77,11 +81,58 @@ describe('auro-tokenlist', () => {
 
     await expect(tableBodyRow1.querySelector("td:nth-of-type(1)")).to.contain.text("var(--ds-color-brand-canyon-300)");
     await expect(tableBodyRow1.querySelector("td:nth-of-type(2)")).to.contain.text("#f26135");
-    await expect(tableBodyRow1.querySelector("td:nth-of-type(3)")).to.contain.html(`<div class="swatch--circle" style="background-color: var(--ds-color-brand-canyon-300)">`);
+    const swatch1 = tableBodyRow1.querySelector("td:nth-of-type(3) div.swatch--circle");
+    await expect(swatch1).to.exist;
+    await expect(swatch1.style.background).to.equal("var(--ds-color-brand-canyon-300)");
 
     await expect(tableBodyRow2.querySelector("td:nth-of-type(1)")).to.contain.text("var(--ds-color-brand-breeze-100)");
     await expect(tableBodyRow2.querySelector("td:nth-of-type(2)")).to.contain.text("#c0f7ff");
-    await expect(tableBodyRow2.querySelector("td:nth-of-type(3)")).to.contain.html(`<div class="swatch--circle" style="background-color: var(--ds-color-brand-breeze-100)">`);
+    const swatch2 = tableBodyRow2.querySelector("td:nth-of-type(3) div.swatch--circle");
+    await expect(swatch2).to.exist;
+    await expect(swatch2.style.background).to.equal("var(--ds-color-brand-breeze-100)");
+
+  });
+
+  it('auro-tokenlist current table with gradient swatch displays gradient background', async () => {
+    const el = await fixture(html`
+      <auro-tokenlist swatchType="rectangle" .componentData=${[]}></auro-tokenlist>
+    `);
+    
+    // Set componentData programmatically to pass an object
+    el.componentData = [{
+      "tokenvalue": {
+        "gradientType": "composite",
+        "layers": [
+          {
+            "gradientType": "linear",
+            "direction": "180deg",
+            "stops": [
+              {"color": "#262043", "alpha": 0.65, "position": "0%"},
+              {"color": "#262043", "alpha": 0, "position": "65%"}
+            ]
+          },
+          {
+            "gradientType": "linear",
+            "direction": "90deg",
+            "stops": [
+              {"color": "#463c8f", "position": "25.8%"},
+              {"color": "#ce0c88", "position": "100%"}
+            ]
+          }
+        ]
+      },
+      "token": "ds-advanced-color-expanded-widget-background"
+    }];
+    
+    await el.updateComplete;
+    await el.updateComplete; // Wait one more cycle to ensure render is complete
+    
+    const tableBodyRow1 = el.shadowRoot.querySelector("tbody tr:nth-of-type(1)");
+
+    await expect(tableBodyRow1.querySelector("td:nth-of-type(1)")).to.contain.text("var(--ds-advanced-color-expanded-widget-background)");
+    await expect(tableBodyRow1.querySelector("td:nth-of-type(2) span.is-gradient")).to.contain.text("linear-gradient(180deg, rgba(38, 32, 67, 0.65) 0%, rgba(38, 32, 67, 0) 65%), linear-gradient(90deg, #463c8f 25.8%, #ce0c88 100%)");
+    await expect(tableBodyRow1.querySelector("td:nth-of-type(3) div.swatch--rectangle")).to.have.class("is-gradient");
+    await expect(tableBodyRow1.querySelector("td:nth-of-type(3)")).to.contain.html(`<div class="swatch--rectangle is-gradient" style="background: var(--ds-advanced-color-expanded-widget-background)">`);
 
   });
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds support for gradient design tokens.

- Auto detects `gradientType` from design tokens, and renders appropriate gradient

## Testing

### DocSite

Tested locally in Docsite:

<img width="1856" height="1069" alt="Screenshot 2025-09-30 at 12 37 21 PM" src="https://github.com/user-attachments/assets/1e2d2686-8506-4c98-9c39-c271c50aa6c0" />

Tokens with the same name that are not gradients still render as solid color tokenlist, as expected:

<img width="1864" height="1079" alt="Screenshot 2025-09-30 at 12 37 42 PM" src="https://github.com/user-attachments/assets/b65142ea-e3d4-464a-8f94-3c66c415780e" />

### `npm run test`

- Added a new gradient test
- Updated a previous test that was affected by adding a trailing space in the class attribute: `(class="swatch--rectangle ")`. This is because when `isGradient()` returns false, the template still has a space: `class="swatch--${this.swatchType} ${this.isGradient(index.tokenvalue) ? 'is-gradient' : ''}"`

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
