### PR TITLE
perf: use `appearance` on icon #30

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -161,10 +161,10 @@ The following example illustrates the standard token display table.
   ```
 </auro-accordion>
 
-This example illustrates the `ondark` token display table.
+This example illustrates the `appearance="inverse"` token display table.
 
 <div class="exampleWrapper">
-  <auro-tokendisplay ondark componentData='[
+  <auro-tokendisplay appearance="inverse" componentData='[
     { "backgroundcolor": "#6bb7fb", "colorname": "color-brand-atlas-200", "usage": "Notification color on light backgrounds" },
     { "backgroundcolor": "#2492eb", "colorname": "color-brand-atlas-300", "usage": "Notification color on light backgrounds" },
     { "backgroundcolor": "#0074cb", "colorname": "color-brand-atlas-400", "usage": "Notification color on light backgrounds" },
@@ -176,7 +176,7 @@ This example illustrates the `ondark` token display table.
   <span slot="trigger">See code</span>
 
   ```html
-  <auro-tokendisplay ondark componentData='[
+  <auro-tokendisplay appearance="inverse" componentData='[
     { "backgroundcolor": "#6bb7fb", "colorname": "color-brand-atlas-200", "usage": "Notification color on light backgrounds" },
     { "backgroundcolor": "#2492eb", "colorname": "color-brand-atlas-300", "usage": "Notification color on light backgrounds" },
     { "backgroundcolor": "#0074cb", "colorname": "color-brand-atlas-400", "usage": "Notification color on light backgrounds" },
@@ -193,11 +193,11 @@ The `<auro-tokenavatar>` custom element is a great UI option for when users may:
 * Use illustrative avatar to display color listing
 * Need to illustrate between text, border, alert, interactive or icon uses
 
-The following example illustrates the auro token avatar with the `avatartype="font"` attribute in standard and ondark modes.
+The following example illustrates the auro token avatar with the `avatartype="font"` attribute in standard with `appearance="inverse"`.
 
 <div class="exampleWrapper">
   <auro-tokenavatar avatartype="font" colorname="ds-color-text-primary-default"></auro-tokenavatar>
-  <auro-tokenavatar avatartype="font" ondark colorname="ds-color-text-primary-inverse"></auro-tokenavatar>
+  <auro-tokenavatar avatartype="font" appearance="inverse" colorname="ds-color-text-primary-inverse"></auro-tokenavatar>
 </div>
 
 <auro-accordion alignRight>
@@ -205,11 +205,11 @@ The following example illustrates the auro token avatar with the `avatartype="fo
 
   ```html
     <auro-tokenavatar avatartype="font" colorname="ds-color-text-primary-default"></auro-tokenavatar>
-    <auro-tokenavatar avatartype="font" ondark colorname="ds-color-text-primary-inverse"></auro-tokenavatar>
+    <auro-tokenavatar avatartype="font" appearance="inverse" colorname="ds-color-text-primary-inverse"></auro-tokenavatar>
   ```
 </auro-accordion>
 
-The following example illustrates the auro token avatar with `avatartype="border"` attribute in standard and ondark modes.
+The following example illustrates the auro token avatar with `avatartype="border"` attribute in standard with `appearance="inverse"`.
 
 <div class="exampleWrapper">
   <auro-tokenavatar avatartype="border" colorname="ds-color-border-error-default"></auro-tokenavatar>
@@ -223,7 +223,7 @@ The following example illustrates the auro token avatar with `avatartype="border
   ```
 </auro-accordion>
 
-The following example illustrates the auro token avatar with `avatartype="alert"` attribute in standard and ondark modes.
+The following example illustrates the auro token avatar with `avatartype="alert"` attribute in standard with `appearance="inverse"`.
 
 <div class="exampleWrapper">
   <auro-tokenavatar avatartype="alert" colorname="ds-color-alert-success-default"></auro-tokenavatar>
@@ -237,11 +237,11 @@ The following example illustrates the auro token avatar with `avatartype="alert"
   ```
 </auro-accordion>
 
-The following example illustrates the auro token avatar with `avatartype="ui"` attribute in standard and ondark modes.
+The following example illustrates the auro token avatar with `avatartype="ui"` attribute in standard with `appearance="inverse"`.
 
 <div class="exampleWrapper">
   <auro-tokenavatar avatartype="ui" colorname="ds-color-ui-default-default"></auro-tokenavatar>
-  <auro-tokenavatar avatartype="ui" ondark colorname="ds-color-ui-default-inverse"></auro-tokenavatar>
+  <auro-tokenavatar avatartype="ui" appearance="inverse" colorname="ds-color-ui-default-inverse"></auro-tokenavatar>
 </div>
 
 <auro-accordion alignRight>
@@ -249,15 +249,15 @@ The following example illustrates the auro token avatar with `avatartype="ui"` a
 
   ```html
   <auro-tokenavatar avatartype="ui" colorname="ds-color-ui-primary-default"></auro-tokenavatar>
-  <auro-tokenavatar avatartype="ui" ondark colorname="ds-color-ui-primary-inverse"></auro-tokenavatar>
+  <auro-tokenavatar avatartype="ui" appearance="inverse" colorname="ds-color-ui-primary-inverse"></auro-tokenavatar>
   ```
 </auro-accordion>
 
-The following example illustrates the auro token avatar with `avatartype="icon"` attribute in standard and ondark modes.
+The following example illustrates the auro token avatar with `avatartype="icon"` attribute in standard with `appearance="inverse"`.
 
 <div class="exampleWrapper">
   <auro-tokenavatar avatartype="icon" colorname='ds-color-ui-default-default'></auro-tokenavatar>
-  <auro-tokenavatar avatartype="icon" ondark colorname='ds-color-ui-default-inverse'></auro-tokenavatar>
+  <auro-tokenavatar avatartype="icon" appearance="inverse" colorname='ds-color-ui-default-inverse'></auro-tokenavatar>
 </div>
 
 <auro-accordion alignRight>
@@ -265,6 +265,6 @@ The following example illustrates the auro token avatar with `avatartype="icon"`
 
   ```html
   <auro-tokenavatar avatartype="icon" colorname='ds-color-ui-default-default'></auro-tokenavatar>
-  <auro-tokenavatar avatartype="icon" ondark colorname='ds-color-ui-default-inverse'></auro-tokenavatar>
+  <auro-tokenavatar avatartype="icon" appearance="inverse" colorname='ds-color-ui-default-inverse'></auro-tokenavatar>
   ```
 </auro-accordion>

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,9 +34,9 @@
     <script type="module" src="../src/auro-tokenlist.js"></script>
     <script type="module" src="../src/auro-tokenavatar.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@alaskaairux/auro-popover@latest/dist/auro-popover__bundled.js" type="module"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-icon@latest/dist/auro-icon__bundled.js" type="module"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-accordion@latest/dist/auro-accordion__bundled.js" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@alaskaairux/auro-popover@latest/+esm" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-icon@latest/+esm" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@aurodesignsystem/auro-accordion@latest/+esm" type="module"></script>
   </body>
 </html>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,16 +4,17 @@ The auro-tokenavatar element provides users a way to illustrate design token col
 
 ## Attributes
 
-| Attribute | Type      | Description                             |
-|-----------|-----------|-----------------------------------------|
-| `ondark`  | `Boolean` | Defines if color state is to be on-dark |
+| Attribute | Type      | Description                            |
+|-----------|-----------|----------------------------------------|
+| `ondark`  | `Boolean` | DEPRECATED - use `appearance` instead. |
 
 ## Properties
 
-| Property     | Attribute    | Type     | Description                                      |
-|--------------|--------------|----------|--------------------------------------------------|
-| `avatartype` | `avatartype` | `String` | Pass in `font`, `border`, `alert`, `ui`, `icon` string to illustrate preferred avatar type |
-| `colorname`  | `colorname`  | `String` | Pass in `-`(dash) to delimitated name of color token |
+| Property     | Attribute    | Type     | Default     | Description                                      |
+|--------------|--------------|----------|-------------|--------------------------------------------------|
+| `appearance` | `appearance` | `string` | "'default'" | Defines whether this component should be light colored for use on dark backgrounds. |
+| `avatartype` | `avatartype` | `string` |             | Pass in `font`, `border`, `alert`, `ui`, `icon` string to illustrate preferred avatar type. |
+| `colorname`  | `colorname`  | `string` |             | Pass in `-`(dash) to delimitated name of color token. |
 
 
 # auro-tokendisplay
@@ -22,10 +23,11 @@ The auro-tokendisplay element provides users a way to illustrate design token co
 
 ## Properties
 
-| Property        | Attribute       | Type      | Description                                      |
-|-----------------|-----------------|-----------|--------------------------------------------------|
-| `componentData` | `componentData` | `Array`   | Pass in `backgroundcolor`, `colorname` & `usage` |
-| `ondark`        | `ondark`        | `Boolean` | Defines if color state is to be on-dark          |
+| Property        | Attribute       | Type      | Default     | Description                                      |
+|-----------------|-----------------|-----------|-------------|--------------------------------------------------|
+| `appearance`    | `appearance`    | `string`  | "'default'" | Defines whether this component should be light colored for use on dark backgrounds. |
+| `componentData` | `componentData` | `array`   |             | Pass in `backgroundcolor`, `colorname` & `usage`. |
+| `ondark`        | `ondark`        | `boolean` |             | DEPRECATED - use `appearance` instead.           |
 
 
 # auro-tokenlist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-tokenlist",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-tokenlist",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -71,95 +71,11 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@alaskaairux/auro-icon": "^3.0.0",
         "@alaskaairux/auro-popover": "^2.2.0",
+        "@aurodesignsystem/auro-icon": "^9.1.0",
         "@webcomponents/webcomponentsjs": "^2.5.0",
         "focus-visible": "^5.2.0"
       }
-    },
-    "node_modules/@alaskaairux/auro-icon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/auro-icon/-/auro-icon-3.4.4.tgz",
-      "integrity": "sha512-eLRjtIq0QXiFMxU1Id9DesTWzt013zJmdzDIPzS+CCWE6WXdSb5LV3eL6T9/8iuCnWubrCyNlwNICGCZitEHUw==",
-      "deprecated": "This version is no longer supported. Please update to @aurodesignsystem/auro-icon for continued support.",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "lit-element": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=12.22.6"
-      },
-      "peerDependencies": {
-        "@alaskaairux/design-tokens": "^3.12.1",
-        "@alaskaairux/webcorestylesheets": "^3.7.3",
-        "@webcomponents/webcomponentsjs": "^2.7.0"
-      }
-    },
-    "node_modules/@alaskaairux/auro-icon/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@alaskaairux/auro-icon/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@alaskaairux/auro-icon/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@alaskaairux/auro-icon/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@alaskaairux/auro-icon/node_modules/lit-element": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
-      "integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
-      "peer": true,
-      "dependencies": {
-        "lit-html": "^1.1.1"
-      }
-    },
-    "node_modules/@alaskaairux/auro-icon/node_modules/lit-html": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-      "peer": true
     },
     "node_modules/@alaskaairux/auro-popover": {
       "version": "2.3.0",
@@ -334,6 +250,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aurodesignsystem/auro-icon": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-icon/-/auro-icon-9.1.0.tgz",
+      "integrity": "sha512-xgjJNknKIKQgHIF2HKyjSG0YGYCg+ladynNxS/IRzaf+RIPlSKu5Hfstc4xyw9VyAy+C48shhpgixZBe2XkarQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "lit": "^3.3.0"
+      },
+      "engines": {
+        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
@@ -9078,7 +9007,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
       "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
-      "dev": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sinon": "^21.0.0"
   },
   "peerDependencies": {
-    "@alaskaairux/auro-icon": "^3.0.0",
+    "@aurodesignsystem/auro-icon": "^9.1.0",
     "@alaskaairux/auro-popover": "^2.2.0",
     "@webcomponents/webcomponentsjs": "^2.5.0",
     "focus-visible": "^5.2.0"

--- a/src/auro-tokenavatar.js
+++ b/src/auro-tokenavatar.js
@@ -11,18 +11,40 @@ import { varName } from "./util.js";
 /**
  * The auro-tokenavatar element provides users a way to illustrate design token colors and their related data for text, border, alert, interactive or icon uses.
  *
- * @attr {String} avatartype - Pass in `font`, `border`, `alert`, `ui`, `icon` string to illustrate preferred avatar type
- * @attr {String} colorname - Pass in `-`(dash) to delimitated name of color token
- * @attr {Boolean} ondark - Defines if color state is to be on-dark
+ * @attr {Boolean} ondark - DEPRECATED - use `appearance` instead.
  */
 
 // build the component class
 class AuroTokenAvatar extends LitElement {
 
+  constructor() {
+    super();
+
+    this.appearance = "default";
+  }
+
   // function to define props used within the scope of this component
   static get properties() {
     return {
+
+      /**
+       * Defines whether this component should be light colored for use on dark backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true
+      },
+
+      /**
+       * Pass in `font`, `border`, `alert`, `ui`, `icon` string to illustrate preferred avatar type.
+       */
       avatartype:   { type: String },
+
+      /**
+       * Pass in `-`(dash) to delimitated name of color token.
+       */
       colorname:    { type: String }
     };
   }

--- a/src/auro-tokendisplay.js
+++ b/src/auro-tokendisplay.js
@@ -13,15 +13,31 @@ import cacheFetch from "./cacheFetch";
 /**
  * The auro-tokendisplay element provides users a way to illustrate design token colors and their related data and usage in a table.
  *
- * @attr {Array} componentData - Pass in `backgroundcolor`, `colorname` & `usage`
- * @attr {Boolean} ondark - Defines if color state is to be on-dark
  */
 
 class AuroTokenDisplay extends LitElement {
   // function to define props used within the scope of this component
   static get properties() {
     return {
+
+      /**
+       * Defines whether this component should be light colored for use on dark backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true
+      },
+
+      /**
+       * Pass in `backgroundcolor`, `colorname` & `usage`.
+       */
       componentData:   { type: Array },
+
+      /**
+       * DEPRECATED - use `appearance` instead.
+       */
       ondark:          { type: Boolean }
     };
   }
@@ -43,7 +59,7 @@ class AuroTokenDisplay extends LitElement {
       auroDarkestBackground = auroDarkestBackground.substring(1);
     }
 
-    const backgroundColor = this.ondark ? auroDarkestBackground : "#FFFFFF";
+    const backgroundColor = this.appearance === 'inverse' || this.ondark ? auroDarkestBackground : "#FFFFFF";
     const dataWithWCAG = await Promise.all(this.componentData.map(async(index) => {
       // empty out any existing 'wcag' value input by the user (for backwards compatibility).
       index.wcag = undefined;
@@ -172,7 +188,7 @@ class AuroTokenDisplay extends LitElement {
                 </div>
                 <auro-icon
                   emphasis
-                  ?ondark="${this.ondark}"
+                  appearance="${this.ondark ? 'inverse' : this.appearance}"
                   id="ratioInfoIcon"
                   category="alert"
                   name="information-stroke"

--- a/src/styles/style-tokenavatar.scss
+++ b/src/styles/style-tokenavatar.scss
@@ -27,7 +27,8 @@
   padding: var(--ds-size-150, vac.$ds-size-150) 0;
 }
 
-:host([ondark]) {
+:host([ondark]),
+:host([appearance="inverse"]) {
   .avatar {
     background-color: var(--ds-color-background-darker, vac.$ds-color-background-darker);
   }

--- a/src/styles/style-tokendisplay.scss
+++ b/src/styles/style-tokendisplay.scss
@@ -17,7 +17,8 @@
   font-weight-notation
 */
 
-:host([ondark]) {
+:host([ondark]),
+:host([appearance="inverse"]) {
   padding: var(--ds-size-100, vac.$ds-size-100);
 
   .tableListing {
@@ -142,7 +143,8 @@
   background-color: var(--ds-color-alert-success-default, vac.$ds-color-alert-success-default);
 }
 
-:host([onDark]) {
+:host([onDark]),
+:host([appearance="inverse"]) {
   .wcagFail,
   .wcagPass {
     color: var(--ds-color-text-primary-default, vac.$ds-color-text-primary-default);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #30

This is to replace `onDark` attr with `appearance` attr. 
- Adding `appearance` with its default value `light`
- Mark `onDark` as deprecated in the api table
- Replace `onDark` with `appearance="inverse"` in all examples

Known issue on popover: https://github.com/AlaskaAirlines/auro-popover/issues/108


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Replace the deprecated ondark attribute with a new appearance attribute to control inverse styling across token avatar and token display components

New Features:
- Introduce appearance attribute with default 'default' on auro-tokenavatar and auro-tokendisplay

Enhancements:
- Deprecate ondark attribute and maintain backward compatibility in component logic
- Update demos and examples to use appearance="inverse" instead of ondark
- Add SCSS support for appearance="inverse" selectors alongside ondark
- Adjust demo index scripts to use +esm CDN URLs for dependencies
- Bump peer dependency of auro-icon to @aurodesignsystem namespace

Documentation:
- Revise API documentation to deprecate ondark and document the appearance attribute